### PR TITLE
fix: 카테고리 필터 적용시 제목 검색 결과 전체에 적용되도록 수정

### DIFF
--- a/src/main/java/com/yaliny/autismmap/community/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/yaliny/autismmap/community/repository/PostRepositoryCustomImpl.java
@@ -23,15 +23,12 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
     @Override
     public Page<Post> searchPost(CategoryType categoryType, String searchText, Pageable pageable) {
+        BooleanExpression searchCondition = searchTextContains(searchText);
+
         List<Post> content = queryFactory
             .selectFrom(post)
             .join(post.member, member).fetchJoin()
-            .where(
-                titleContains(searchText)
-                    .or(contentContains(searchText))
-                    .or(memberNickNameContains(searchText))
-                    .and(categoryTypeEq(categoryType))
-            )
+            .where(searchCondition, categoryTypeEq(categoryType))
             .orderBy(post.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -40,27 +37,20 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
         Long total = queryFactory
             .select(post.count())
             .from(post)
-            .where(
-                titleContains(searchText)
-                    .or(contentContains(searchText))
-                    .or(memberNickNameContains(searchText))
-                    .and(categoryTypeEq(categoryType))
-            )
+            .where(searchCondition, categoryTypeEq(categoryType))
             .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
-    private BooleanExpression titleContains(String searchText) {
-        return searchText != null ? post.title.contains(searchText) : null;
-    }
+    private BooleanExpression searchTextContains(String searchText) {
+        if (searchText == null || searchText.isBlank()) {
+            return null;
+        }
 
-    private BooleanExpression contentContains(String searchText) {
-        return searchText != null ? post.content.contains(searchText) : null;
-    }
-
-    private BooleanExpression memberNickNameContains(String searchText) {
-        return searchText != null ? post.member.nickname.contains(searchText) : null;
+        return post.title.contains(searchText)
+            .or(post.content.contains(searchText))
+            .or(post.member.nickname.contains(searchText));
     }
 
     private BooleanExpression categoryTypeEq(CategoryType categoryType) {

--- a/src/test/java/com/yaliny/autismmap/community/repository/PostRepositoryTest.java
+++ b/src/test/java/com/yaliny/autismmap/community/repository/PostRepositoryTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
@@ -47,5 +49,27 @@ class PostRepositoryTest {
         assertThat(findPost.getTitle()).isEqualTo(title);
         assertThat(findPost.getContent()).isEqualTo(content);
         assertThat(findPost.getCategory()).isEqualTo(category);
+    }
+
+    @Test
+    @DisplayName("카테고리 필터는 제목 검색 결과 전체에 적용된다")
+    void searchPost_appliesCategoryFilterToWholeSearchCondition() {
+        Member member = Member.createMember("filter@test.com", "test", "writer");
+        memberRepository.save(member);
+
+        Post freePost = Post.createPost(CategoryType.FREE, "같은검색어", "free content", member);
+        Post questionPost = Post.createPost(CategoryType.QNA, "같은검색어", "question content", member);
+
+        postRepository.save(freePost);
+        postRepository.save(questionPost);
+
+        Page<Post> result = postRepository.searchPost(
+            CategoryType.FREE,
+            "같은검색어",
+            PageRequest.of(0, 10)
+        );
+
+        assertThat(result.getContent()).extracting(Post::getCategory)
+            .containsExactly(CategoryType.FREE);
     }
 }


### PR DESCRIPTION
https://github.com/Yelin-park/autism-map/issues/25